### PR TITLE
COL-799 Retain configured tick format on zoom

### DIFF
--- a/lib/zoom.js
+++ b/lib/zoom.js
@@ -10,12 +10,12 @@ export default (container, dimensions, scales, configuration, data, callback) =>
             
             if(boolOrReturnValue(configuration.hasTopAxis, data)){
                 container.selectAll('.x-axis.top')
-                         .call(d3.axisTop().scale(scalingFunction));
+                         .call(d3.axisTop().scale(scalingFunction).tickFormat(configuration.tickFormat));
             }  
             
             if(boolOrReturnValue(configuration.hasBottomAxis, data)){
                 container.selectAll('.x-axis.bottom')
-                         .call(d3.axisBottom().scale(scalingFunction));    
+                         .call(d3.axisBottom().scale(scalingFunction).tickFormat(configuration.tickFormat));    
             }
 
             const sumDataCount = debounce(labels(container.select('.labels'),{ x : scalingFunction},configuration),100);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-799

Without this change, the custom 24-hour format defined in ets-berkeley-edu/suitec#358 disappears on the first zoom or pan.