### PR TITLE
NOJIRA Remove redundant d3 import statements

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,3 @@
-import * as d3 from  'd3/build/d3';
-
 const config = {
     lineHeight: 40,
     start: new Date(0),

--- a/lib/drawer/drops.js
+++ b/lib/drawer/drops.js
@@ -1,5 +1,3 @@
-import * as d3 from 'd3/build/d3';
-
 export default (container, scales, configuration) =>
     function dropsSelector(data) {
         const dropLines = container

--- a/lib/eventDrops.js
+++ b/lib/eventDrops.js
@@ -1,5 +1,3 @@
-import * as d3 from 'd3/build/d3';
-
 import configurable from 'configurable.js';
 import defaultConfig from './config';
 import drawer from './drawer';

--- a/lib/xAxis.js
+++ b/lib/xAxis.js
@@ -1,5 +1,3 @@
-import * as d3 from 'd3/build/d3'
-
 export default function(xScale, configuration, where) {
     
     const tickFormat = configuration.locale ? configuration.locale.timeFormat : configuration.tickFormat;

--- a/lib/zoom.js
+++ b/lib/zoom.js
@@ -1,4 +1,3 @@
-import * as d3 from 'd3/build/d3';
 import xAxis from './xAxis';
 import { delimiters } from './drawer/delimiters';
 import labels from './drawer/labels';


### PR DESCRIPTION
Equivalent to https://github.com/marmelab/EventDrops/pull/145 over at the main project. d3 is already available as a global through the Webpack configuration; these re-imports cause conflicts and surprising null references.